### PR TITLE
fontconfig and golang fixes to che-dev Dockerfile

### DIFF
--- a/che-dev/Dockerfile.centos
+++ b/che-dev/Dockerfile.centos
@@ -32,7 +32,7 @@ ENV NODE_VERSION=0.12.9 \
 
 RUN sudo yum -y update && \
     sudo yum -y install @"Development Tools" && \
-    sudo yum -y install openssl-devel krb5-devel gcc make ruby ruby-devel rubygems golang && \
+    sudo yum -y install openssl-devel krb5-devel gcc make ruby ruby-devel rubygems golang fontconfig && \
     sudo gem install sass compass && \
     sudo yum clean all 
 
@@ -57,11 +57,8 @@ RUN set -ex \
 EXPOSE 3000 5000 9000
 RUN sudo npm install -g npm@latest
 RUN sudo npm install --unsafe-perm -g gulp bower
+
 RUN mkdir ~/gopath 
-    # sudo tar -xvf go1.6.2.linux-amd64.tar.gz -C /opt/ && \
-    # rm go1.6.2.linux-amd64.tar.gz
-ENV GOROOT=/usr/bin/go
 ENV GOPATH=/home/user/gopath
-RUN echo "export PATH=$GOROOT/bin:$PATH" >> ~/.bashrc
 
 WORKDIR /home/user


### PR DESCRIPTION
With these fixes we should be able to build Che using a centos based image
